### PR TITLE
ingress tls definition needs a host name if used with cert-manager (eg ACME/let's encrypt)

### DIFF
--- a/helm-charts/nxrm-ha/templates/ingress.yaml
+++ b/helm-charts/nxrm-ha/templates/ingress.yaml
@@ -39,6 +39,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
+        - {{ .Values.ingress.host }}
       {{- if .Values.ingress.tls.secretName }}
       secretName: {{ .Values.ingress.tls.secretName }}
       {{- end }}


### PR DESCRIPTION
tittle says it all, ingress tls definition needs a host name if used with cert-manager (eg ACME/let's encrypt)