### PR TITLE
NEXUS-43067 - Update ubi8 Mimimal to the Latest Image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT MODIFY. This is produced by template.
-FROM quay.io/operator-framework/helm-operator@sha256:e82703bd9ce640b048c00d0c2e860d784cd0c5bfb724869c1aba85e92a13ce58
+FROM quay.io/operator-framework/helm-operator@sha256:de2a0a20c1c3b39c3de829196de9694d09f97cd18fda1004de855ed2b4c841ba
 
 # Required OpenShift Labels
 LABEL name="Nexus Repository HA Operator" \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT MODIFY. This is produced by template.
-FROM quay.io/operator-framework/helm-operator@sha256:de2a0a20c1c3b39c3de829196de9694d09f97cd18fda1004de855ed2b4c841ba
+FROM quay.io/operator-framework/helm-operator@sha256:9ff9668e2be6efeb00d4698152d1358888c26cee38a0fe2b78d48671de1da62e
 
 # Required OpenShift Labels
 LABEL name="Nexus Repository HA Operator" \


### PR DESCRIPTION
[JIRA](https://sonatype.atlassian.net/browse/NEXUS-43067) 

Update docker file with latest image from [helm-operator](https://quay.io/repository/operator-framework/helm-operator?tab=tags)
Verified with Sonatype IQ CLI that no policy violations are detected
