### PR TITLE
NEXUS-43640 - Remove WATCH_NAMESPACE env variable as it is deprecated

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,10 +29,6 @@ spec:
               drop:
                 - ALL
           env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/scripts/templates/nexus-repository-ha-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nexus-repository-ha-operator-certified.clusterserviceversion.yaml
@@ -354,10 +354,6 @@ spec:
               spec:
                 containers:
                   - env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: POD_NAME
                         valueFrom:
                           fieldRef:

--- a/scripts/templates/operator.yaml
+++ b/scripts/templates/operator.yaml
@@ -29,10 +29,6 @@ spec:
               drop:
                 - ALL
           env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Remove the WATCH_NAMESPACE env variable as it is deprecated.

With the update to the latest helm operator base image, the presence of this env variable was preventing the Nexus Repo operator's resources from being created when the operator is installed into a specific namespace