### PR TITLE
Update expired image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT MODIFY. This is produced by template.
-FROM quay.io/operator-framework/helm-operator@sha256:9ff9668e2be6efeb00d4698152d1358888c26cee38a0fe2b78d48671de1da62e
+FROM quay.io/operator-framework/helm-operator@sha256:ecb23393140d2553d97ba9de4d75a7d9aac6a76c9390d22824941e89b983bb68
 
 # Required OpenShift Labels
 LABEL name="Nexus Repository HA Operator" \

--- a/scripts/templates/Dockerfile
+++ b/scripts/templates/Dockerfile
@@ -1,5 +1,5 @@
 # {{templateWarning}}
-FROM quay.io/operator-framework/helm-operator@sha256:9ff9668e2be6efeb00d4698152d1358888c26cee38a0fe2b78d48671de1da62e
+FROM quay.io/operator-framework/helm-operator@sha256:ecb23393140d2553d97ba9de4d75a7d9aac6a76c9390d22824941e89b983bb68
 
 # Required OpenShift Labels
 LABEL name="Nexus Repository HA Operator" \


### PR DESCRIPTION
The old image was expired effective July 29th. This is the newest version that still keeps the same mediatype

_"mediaType": "application/vnd.docker.distribution.manifest.v2+json"_



Expired image:
{
  "name": "latest",
  "reversion": false,
  "start_ts": 1718735113,
  "end_ts": 1722281684,
  "manifest_digest": "sha256:9ff9668e2be6efeb00d4698152d1358888c26cee38a0fe2b78d48671de1da62e",
  "is_manifest_list": true,
  "size": null,
  "last_modified": "Tue, 18 Jun 2024 18:25:13 -0000",
  "expiration": "Mon, 29 Jul 2024 19:34:44 -0000"
}