### PR TITLE
Remove prefix from secret mapping

### DIFF
--- a/helm-charts/nxrm-ha/templates/nexus-secret-mapping.yaml
+++ b/helm-charts/nxrm-ha/templates/nexus-secret-mapping.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Chart.Name }}-{{ .Chart.Version}}-{{ .Release.Name }}-{{ .Values.secret.nexusSecret.name }}
+  name: {{ .Values.secret.nexusSecret.name }}
 type: Opaque
 data:
   {{ .Values.secret.nexusSecret.name }}: |-

--- a/helm-charts/nxrm-ha/tests/nexus-secret-mapping_test.yaml
+++ b/helm-charts/nxrm-ha/tests/nexus-secret-mapping_test.yaml
@@ -18,7 +18,7 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
-          value: "nxrm-ha-latest-test-release-nexus-secret.json"
+          value: "nexus-secret.json"
 
       - equal:
           path: data


### PR DESCRIPTION
The nexus-secret-mapping.yaml prefixes the value specified in .Values.secret.nexusSecret.name with {{ .Chart.Name }}-{{ .Chart.Version}}-{{ .Release.Name }}but in the [statefulset](https://github.com/sonatype/operator-nexus-repository/blob/d4445cba691d99223100b0a8186769ca18826d3b/helm-charts/nxrm-ha/templates/statefulset.yaml#L125) it tries to mount it using just the .Values.secret.nexusSecret.namewhich causes the volume binding to fail.

Fix is to remove the prefix from this [line](https://github.com/sonatype/operator-nexus-repository/blob/d4445cba691d99223100b0a8186769ca18826d3b/helm-charts/nxrm-ha/templates/nexus-secret-mapping.yaml#L5)