### PR TITLE
Upgrading openshift to 1.14.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node('ubuntu-zion') {
       sh 'docker system prune -a -f'
       sh '''
         wget -q -O preflight \
-          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.13.0/preflight-linux-amd64
+          https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
         chmod 755 preflight
       '''
     }


### PR DESCRIPTION
This pull request updates the version of the `preflight` binary downloaded in the Jenkins pipeline. The change ensures that the build process uses the latest available version of the tool.

* CI/CD pipeline update:
  * In `Jenkinsfile`, the download URL for the `preflight` binary was updated from version `1.13.0` to `1.14.1` to use the latest release.