### PR TITLE
Openshift 3.84.0-3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,9 +3,8 @@ FROM quay.io/operator-framework/helm-operator@sha256:ecb23393140d2553d97ba9de4d7
 
 # Required OpenShift Labels
 LABEL name="Nexus Repository HA Operator" \
-      maintainer="Sonatype" \
       vendor="Sonatype" \
-      version="3.80.0" \
+      version="3.84.0" \
       release="1" \
       summary="The Nexus Repository with universal support for popular component formats." \
       description="The Nexus Repository with universal support for popular component formats."

--- a/helm-charts/nxrm-ha/Chart.yaml
+++ b/helm-charts/nxrm-ha/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 80.0.0
+version: 84.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 3.80.0
+appVersion: 3.84.0
 
 keywords:
   - artifacts

--- a/helm-charts/nxrm-ha/values.yaml
+++ b/helm-charts/nxrm-ha/values.yaml
@@ -4,7 +4,7 @@ statefulset:
   name: nexusrepo-statefulset
   replicaCount: 1
   container:
-    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.80.0-ubi-2
+    imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.84.0-ubi-1
     resources:
       # See help documentation, these are minimum system requirements
       requests:


### PR DESCRIPTION
This pull request updates the Nexus Repository HA Operator and its Helm chart to use version 3.84.0 of the application. The most important changes are grouped below by theme.

**Version Updates:**

* Updated the application version from `3.80.0` to `3.84.0` in the Dockerfile label, Helm chart `Chart.yaml`, and values file to ensure the deployment uses the latest release. [[1]](diffhunk://#diff-5aecd73bbcb9b7410938673269f0d4e676dd18509277b0ff2f2787c9d3e22604L6-R7) [[2]](diffhunk://#diff-db06e0efc8bb8bc6d2948a487ee9c38f1eb635ebf50bca5ba53e7e54c77cae6bL19-R25) [[3]](diffhunk://#diff-609f28eabc27efc1192b602b868f04ef338945809589601645a86174a0d94cb0L7-R7)
* Updated the Helm chart version from `80.0.0` to `84.0.0` in `Chart.yaml` to reflect the new release.

**Image Reference Update:**

* Changed the container image in `values.yaml` to use `registry.connect.redhat.com/sonatype/nexus-repository-manager:3.84.0-ubi-1` for the statefulset, aligning with the new application version.

**Metadata Cleanup:**

* Removed the `maintainer` label from the Dockerfile for metadata simplification.