### PR TITLE
Bundle files creation.

### DIFF
--- a/deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml
+++ b/deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml
@@ -71,7 +71,7 @@ spec:
         password: nexus
         user: nexus
         zeroDowntimeEnabled: false
-      imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:e7f8e33149a0aabbfe18c561f07320fbbf0b7040a56bb97c2e83dfb8d9482a92
+      imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:fbad488ff2e368845473a11b4955992fe826a94811da3abf5cc3c6a33ff3974f
       pullPolicy: IfNotPresent
       resources:
         limits:

--- a/deploy/olm-catalog/nexus-repository-ha-operator-certified/nexus-repository-ha-operator-certified.package.yaml
+++ b/deploy/olm-catalog/nexus-repository-ha-operator-certified/nexus-repository-ha-operator-certified.package.yaml
@@ -1,7 +1,7 @@
 # DO NOT MODIFY. This is produced by template.
 ---
 channels:
-  - currentCSV: nexus-repository-ha-operator-certified.v3.80.0-2
+  - currentCSV: nexus-repository-ha-operator-certified.v3.84.0-1
     name: stable
 defaultChannel: stable
 packageName: nexus-repository-ha-operator-certified

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: nexus-repository-ha-operator-certified
           # Replace this with the built image name
-          image: registry.connect.redhat.com/sonatype/nexus-repository-ha-operator-certified@sha256:a270bfb6f26520e8efba107af8c8dca3ce567774a8e5a0a252a7b5838a0a5e5e
+          image: registry.connect.redhat.com/sonatype/nexus-repository-ha-operator-certified@sha256:99f30aa5ba8469d96de3efe69d1b21e73ff022172fc79144bba496d1119ec8a2
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -36,4 +36,4 @@ spec:
             - name: OPERATOR_NAME
               value: "nexus-repository-ha-operator-certified"
             - name: RELATED_IMAGE_NEXUS
-              value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:e7f8e33149a0aabbfe18c561f07320fbbf0b7040a56bb97c2e83dfb8d9482a92
+              value: registry.connect.redhat.com/sonatype/nexus-repository-manager@sha256:fbad488ff2e368845473a11b4955992fe826a94811da3abf5cc3c6a33ff3974f


### PR DESCRIPTION
This pull request updates the container images for both the Nexus Repository Manager and the Nexus Repository HA Operator Certified, ensuring the deployment uses the latest versions. It also updates the Operator Lifecycle Manager (OLM) package manifest to reference the new operator release.

**Image Updates:**

* Updated the `imageName` for `nexus-repository-manager` in `deploy/crds/sonatype.com_v1alpha1_nexusrepo_cr.yaml` to use the latest image digest.
* Updated the `image` for the `nexus-repository-ha-operator-certified` container in `deploy/operator.yaml` to use the latest image digest.
* Updated the `RELATED_IMAGE_NEXUS` environment variable in `deploy/operator.yaml` to reference the new `nexus-repository-manager` image digest.

**OLM Manifest Update:**

* Updated the `currentCSV` in `deploy/olm-catalog/nexus-repository-ha-operator-certified/nexus-repository-ha-operator-certified.package.yaml` to reference the new operator release version `v3.84.0-1`.